### PR TITLE
docs: AI harness readiness — AGENTS.md, ARCHITECTURE.md, CONTRIBUTING.md, first ADR [DX-1340]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,78 @@
+# AGENTS.md
+
+Guidance for coding agents working in `contentful/svelte-intro`.
+
+## What this repo is
+
+A minimal Svelte 3 + Vite demo application. It was scaffolded from the
+`create-vite` `svelte` (JavaScript) template — `README.md` is still largely the
+template's own text — and then extended with a small hardcoded product-card
+example.
+
+It is a teaching/intro app, not a maintained product:
+
+- `package.json` is `"private": true` at version `0.0.0`. Nothing is published.
+- There is no test suite, no linter, and no `.github/workflows` directory.
+- The only substantive application commit is `fa76730` ("First commit",
+  2023-06-20). Every commit since then touches `catalog-info.yaml`,
+  `.github/CODEOWNERS`, or `.npmrc` — repository plumbing, not features.
+- Despite living in the `contentful` org, the app does not use any Contentful
+  SDK and makes no network calls to Contentful. Do not add a Contentful
+  integration unless a ticket explicitly asks for one.
+
+Owner: `@contentful/team-devrel` (`.github/CODEOWNERS`).
+
+## Commands
+
+These are the only scripts defined in `package.json`:
+
+```bash
+npm run dev      # vite        — dev server with HMR
+npm run build    # vite build  — production build into dist/
+npm run preview  # vite preview — serve the built dist/ locally
+```
+
+There is no `npm test` and no `npm run lint`. Do not invent one in a report;
+if a task needs verification, run `npm run build` and check it completes.
+
+`.npmrc` sets `ignore-scripts=true`, so `npm install` / `npm ci` will not run
+dependency lifecycle scripts. Leave that setting alone — see
+`docs/ADRs/2026-08-25-ignore-npm-lifecycle-scripts.md`.
+
+## Where things live
+
+- `index.html` — Vite's HTML entry point; loads `/src/main.js`.
+- `src/main.js` — mounts `App.svelte` into `#app`.
+- `src/App.svelte` — the whole page: a hardcoded `data` array and a `Card` per item.
+- `src/lib/` — `Card.svelte`, `Counter.svelte`, `store.js`.
+- `vite.config.js` — Vite config; the Svelte plugin is the only plugin.
+- `jsconfig.json` — `checkJs: true`, so editors typecheck the plain JS and
+  `.svelte` files. Type errors surface in the editor, not in a build gate.
+
+See `ARCHITECTURE.md` for how these fit together.
+
+## Gotchas worth knowing before you edit
+
+- `src/app.css` exists but is empty (0 bytes). All styling comes from the
+  `@import` statements in `App.svelte`'s `<style global>` block, which pull
+  `open-props` from `unpkg.com` at runtime. The app therefore looks unstyled
+  offline, and `Card.svelte`'s `var(--font-weight-8)` / `var(--font-weight-4)`
+  resolve to nothing without that CDN.
+- `Counter.svelte` is imported by `App.svelte` but never rendered. So is the
+  `hasVat` store import in `App.svelte` — only `Card.svelte` actually reads it.
+- Nothing ever writes to the `hasVat` store, so the 1.2x VAT multiplier in
+  `Card.svelte` is always applied. There is no UI to toggle it.
+- The demo product titles read `"Prodcut 1"`, `"Prodcut 2"`, `"Prodcut 3"` —
+  a typo in the original commit, not a fixture other code depends on.
+- `catalog-info.yaml` is still the unfilled Backstage template: `description`,
+  `type`, `lifecycle`, and `system` are all `unknown`, and the tags include
+  `update-me` and `tier-unknown`. Treat its metadata as unreliable.
+
+## Conventions
+
+- Commit subjects follow Conventional Commits (`fix:`, `chore:`, `docs:`), as
+  seen in `git log`. There is no release automation configured in this repo, so
+  the prefix is a readability convention only.
+- Svelte 3 syntax throughout (`new App({ target })` in `main.js`,
+  `on:click`, `export let` props). This is not Svelte 4 or 5 — check the
+  `svelte` version in `package.json` before applying newer idioms.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,96 @@
+# Architecture
+
+`svelte-intro` is a single-page Svelte 3 application built with Vite. There is
+no server, no router, no persistence layer, and no external API client — the
+entire app is three components and one store rendering hardcoded data.
+
+## Directory layout
+
+```
+index.html            Vite HTML entry; loads /src/main.js as a module
+vite.config.js        Vite config — @sveltejs/vite-plugin-svelte, no other plugins
+jsconfig.json         Editor/TS settings; checkJs enabled, includes src/**
+.npmrc                ignore-scripts=true
+.vscode/extensions.json  Recommends svelte.svelte-vscode
+catalog-info.yaml     Backstage descriptor (still the unfilled template)
+public/vite.svg       Static asset served at /vite.svg (the favicon)
+src/
+  main.js             Mounts App into #app
+  app.css             Present but empty (0 bytes)
+  vite-env.d.ts       Triple-slash refs for svelte and vite/client types
+  assets/svelte.svg   Imported by App.svelte
+  App.svelte          Root component: hardcoded product list
+  lib/
+    Card.svelte       Renders one product, applies VAT
+    Counter.svelte    Click counter (imported but not rendered)
+    store.js          Exports the `hasVat` writable store
+```
+
+## Boot sequence
+
+1. Vite serves `index.html`, which contains `<div id="app">` and a module
+   script tag pointing at `/src/main.js`.
+2. `src/main.js` imports `./app.css` (currently a no-op — the file is empty),
+   imports `App.svelte`, and instantiates it with
+   `new App({ target: document.getElementById('app') })`. This is the Svelte 3
+   client component API.
+3. The instance is exported as the module's default. Nothing consumes that
+   export; it exists so the module has a stable entry value.
+
+## Component graph and data flow
+
+`App.svelte` is the only page. It declares a module-local `data` array of three
+objects (`title`, `description`, `price`) and renders one `Card` per entry via
+`{#each}`, passing each field as a separate prop.
+
+`Card.svelte` receives `title`, `description`, and `price` (defaulting to `0`)
+through `export let`. It imports the `hasVat` store from `./store` and calls
+`hasVat.subscribe(...)` directly, copying the value into a local
+`hasVatValue`. The rendered price is `hasVatValue ? price * 1.2 : price`.
+
+`src/lib/store.js` is the only shared state: a single
+`writable(true)` exported as `hasVat`. No code in the repo ever calls
+`hasVat.set` or `hasVat.update`, so the store is effectively a compile-time
+constant and the 1.2x multiplier always applies. There is no UI control for it.
+
+`Counter.svelte` holds its own `count` and an `increment` handler. `App.svelte`
+imports it but does not place it in the template, so it never mounts. It is
+leftover scaffolding from the `create-vite` template.
+
+Data flow is therefore one-directional and shallow: `App` → props → `Card`,
+plus one read-only store subscription in `Card`. There are no events bubbling
+back up (`createEventDispatcher` is not used anywhere).
+
+## Styling
+
+There is no local stylesheet in use. `App.svelte` declares a
+`<style global>` block whose entire content is two `@import` rules pointing at
+`https://unpkg.com/open-props` and
+`https://unpkg.com/open-props/normalize.min.css`. Those are resolved by the
+browser at runtime, not bundled.
+
+Consequences worth being aware of:
+
+- The app depends on `unpkg.com` being reachable to look correct. Offline or
+  behind a restrictive CSP it renders unstyled.
+- `Card.svelte`'s scoped styles reference `var(--font-weight-8)` and
+  `var(--font-weight-4)`, which are Open Props custom properties. Without the
+  CDN import they resolve to nothing and the browser falls back to defaults.
+- `src/app.css` is the conventional place for global styles and is already
+  wired up through `main.js`, so it is the natural home for anything that
+  should be bundled rather than fetched.
+
+## Build and output
+
+`npm run build` runs `vite build`, which bundles from `index.html` into `dist/`.
+`dist/` and `dist-ssr/` are gitignored. `npm run preview` serves that output.
+`npm run dev` runs the Vite dev server with HMR.
+
+Note that HMR does not preserve component state — this is a documented
+`@sveltejs/vite-plugin-svelte` default and is discussed in `README.md`. State
+that must survive a hot update belongs in an external store like
+`src/lib/store.js`.
+
+There is no CI in this repository: no `.github/workflows` directory exists, so
+nothing builds, lints, or tests on push. `.github/CODEOWNERS` assigns all paths
+to `@contentful/team-devrel`, which is the only automated gate on changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,93 @@
+# Contributing
+
+`svelte-intro` is a small Svelte + Vite demo app owned by
+`@contentful/team-devrel`. It is not published to npm (`package.json` is
+`"private": true` at version `0.0.0`) and it is not deployed from this
+repository. Changes here are almost always in service of a demo, a workshop, or
+keeping the dependencies from rotting.
+
+The repo has been quiet since its first commit in June 2023 — everything after
+that is repository plumbing. Please keep changes small and self-contained.
+
+## Prerequisites
+
+- Node.js with npm. No engine range is pinned in `package.json`; a Node version
+  new enough for Vite 3 works.
+- Nothing else. There are no environment variables, no `.env` file, and no
+  Contentful credentials involved — the app renders hardcoded data.
+
+## Getting set up
+
+```bash
+npm install       # or npm ci, if you want the lockfile enforced
+npm run dev       # Vite dev server with HMR
+```
+
+`.npmrc` sets `ignore-scripts=true`, so dependency lifecycle scripts do not run
+during install. This is deliberate; see
+`docs/ADRs/2026-08-25-ignore-npm-lifecycle-scripts.md`. Do not pass
+`--ignore-scripts=false` to work around a failing install — figure out which
+dependency needs a postinstall step and run it explicitly instead.
+
+## Verifying a change
+
+There is no test suite and no linter in this repository. The available checks
+are:
+
+```bash
+npm run build     # vite build — must complete without errors
+npm run preview   # serve dist/ and click through the page
+```
+
+Because `jsconfig.json` sets `"checkJs": true`, your editor will typecheck the
+plain JavaScript and `.svelte` files. Those diagnostics are the closest thing
+to a static analysis gate, so install the recommended
+`svelte.svelte-vscode` extension (`.vscode/extensions.json`) and clear
+warnings in the files you touch.
+
+Please state in your PR what you actually ran and what you saw. Do not claim a
+test suite passed — there isn't one.
+
+## Making a change
+
+1. Branch from `main`.
+2. Keep the change scoped. If you are adding a component, put it in `src/lib/`
+   alongside `Card.svelte` and `Counter.svelte`.
+3. Match the existing style: two-space indentation, single quotes in `.js`
+   files, no semicolon discipline enforced either way, Svelte 3 idioms
+   (`export let` props, `on:click`, `new App({ target })`). Do not introduce
+   Svelte 4 or 5 syntax without bumping the `svelte` dependency in the same PR
+   and saying so.
+4. Write commit subjects as Conventional Commits — `fix:`, `chore:`, `docs:`,
+   `feat:` — matching the existing history. There is no semantic-release setup
+   in this repo, so the prefix is for readability rather than versioning.
+5. Open a PR against `main`. `.github/CODEOWNERS` requests review from
+   `@contentful/team-devrel` automatically. No CI runs, so a human reading the
+   diff is the entire quality gate — make the diff easy to read.
+
+## Things to leave alone
+
+- `.gitignore` — do not loosen it. `dist/`, `node_modules`, and `*.local` must
+  stay ignored.
+- `.npmrc` — see the ADR above.
+- `README.md`'s "Technical considerations" section is inherited verbatim from
+  the `create-vite` template and explains upstream template choices. Rewriting
+  it loses that provenance; add repo-specific notes to `ARCHITECTURE.md` or
+  `AGENTS.md` instead.
+
+## Known rough edges
+
+If you are looking for something small to fix, these are real and documented in
+`AGENTS.md`:
+
+- `src/app.css` is empty; all styling is `@import`ed from `unpkg.com` at
+  runtime, so the app is unstyled offline.
+- `Counter.svelte` is imported by `App.svelte` but never rendered, and
+  `App.svelte`'s `hasVat` import is unused.
+- Nothing writes to the `hasVat` store, so VAT is permanently on with no way to
+  toggle it.
+- The demo product titles are misspelled `"Prodcut"`.
+- `catalog-info.yaml` is still the unfilled Backstage template — `description`,
+  `type`, `lifecycle`, and `system` are all `unknown`, and the file carries a
+  warning comment saying it must be filled in before merging to the default
+  branch. It was merged anyway in `63198f5`.

--- a/docs/ADRs/2026-08-25-ignore-npm-lifecycle-scripts.md
+++ b/docs/ADRs/2026-08-25-ignore-npm-lifecycle-scripts.md
@@ -1,0 +1,64 @@
+# Ignore npm lifecycle scripts on install
+
+- **Date:** 2026-08-25 (record written); decision made 2025-11-26
+- **Status:** Accepted — in effect on `main`
+
+> This record was written on 2026-08-25 from the commit history. It documents an
+> existing decision rather than a new one, and the rationale below is
+> reconstructed from the change itself — the original commit message and PR
+> title record no reasoning. Where intent could not be established, this record
+> says what is true and stops.
+
+## Context
+
+`svelte-intro` is a private, unpublished Svelte + Vite demo app. Its dependency
+tree is small — three direct devDependencies (`svelte`,
+`vite`, `@sveltejs/vite-plugin-svelte`) — but the transitive tree resolved
+through `package-lock.json` is not, and any package in it can declare
+`preinstall`, `install`, or `postinstall` scripts that npm executes on the
+machine running the install.
+
+By default npm runs those scripts. Nothing in this repository needs them: the
+three devDependencies are pure JavaScript, there is no native addon to compile,
+and there is no build step wired to a lifecycle hook. The only npm scripts
+declared in `package.json` are `dev`, `build`, and `preview`, all invoked
+explicitly by a developer.
+
+## Decision
+
+An `.npmrc` at the repository root sets:
+
+```
+ignore-scripts=true
+```
+
+Evidence: commit
+[`36331ef`](https://github.com/contentful/svelte-intro/commit/36331efdfffcde5a5013f44af2cc68049cee3a68)
+("chore: [] ignore npm scripts (#5)", 2025-11-26), which created `.npmrc` as a
+single-line file. That is the entire diff — one insertion, no other files
+touched. The empty `[]` in the subject looks like an unfilled slot in a
+templated commit message, which suggests the change arrived as part of a batch
+across repositories rather than in response to something specific in this one;
+that reading is inference from the message format, not something the history
+confirms.
+
+The mechanical effect is what the npm setting does: `npm install` and `npm ci`
+resolve and unpack dependencies but do not execute any package's lifecycle
+scripts. No package in the current tree requires one, so installs succeed
+without them.
+
+## Consequences
+
+- Installs in this repository do not execute third-party install-time code.
+  That removes install-time script execution as a path for anything in the
+  transitive tree to run on a developer's machine or in a future CI job.
+- If a dependency is ever added that genuinely requires a postinstall step —
+  a native module, a binary downloader — the install will succeed while leaving
+  that dependency unusable, and the failure will surface later and less
+  obviously than an install error would. Run the required step explicitly
+  rather than removing this setting.
+- Do not work around a failing install with `--ignore-scripts=false`. Identify
+  the dependency that needs the hook and handle it directly, or open a PR that
+  changes this decision on purpose.
+- The setting is repository-local. Anyone installing this project's
+  dependencies outside a checkout of this repo will not inherit it.

--- a/docs/ADRs/README.md
+++ b/docs/ADRs/README.md
@@ -1,0 +1,8 @@
+# Decision records
+
+Architectural decision records for `svelte-intro`. One file per decision, named
+`YYYY-MM-DD-<kebab-case-title>.md`.
+
+- [2026-08-25 — Ignore npm lifecycle scripts on install](./2026-08-25-ignore-npm-lifecycle-scripts.md):
+  `.npmrc` sets `ignore-scripts=true`, so `npm install` and `npm ci` do not run
+  dependency lifecycle scripts.


### PR DESCRIPTION
Closes all four AI harness readiness controls for this repo (DX-1340, parent DX-1296). The audit on 2026-08-19 found 0 of 4 satisfied.

**This PR comes from a fork** (`chasepoirier:docs/dx-1340-ai-harness-readiness`) because the author does not have write access to `contentful/svelte-intro`. A maintainer on `@contentful/team-devrel` should confirm ownership and merge, or take the branch over.

## Controls closed

| Control | File |
| --- | --- |
| `agents-md-present` | `AGENTS.md` (60 non-blank lines) |
| `architecture-md-present` | `ARCHITECTURE.md` (77 non-blank lines) |
| `contributing-md-present` | `CONTRIBUTING.md` (74 non-blank lines) |
| `decision-records-present` | `docs/ADRs/2026-08-25-ignore-npm-lifecycle-scripts.md` (52 non-blank lines) |

Also adds `docs/ADRs/README.md` as the record index.

## What the docs say

Everything is drawn from the repo as it actually is, not from Svelte/Vite convention:

- **AGENTS.md** — states plainly that this is a dormant `create-vite` Svelte 3 demo: private, version `0.0.0`, no test suite, no linter, no `.github/workflows`, and no Contentful SDK anywhere despite the org. Documents the three real scripts (`dev`, `build`, `preview`) and the gotchas that matter before editing: `src/app.css` is empty (0 bytes) so all styling is `@import`ed from `unpkg.com` at runtime; `Counter.svelte` is imported by `App.svelte` but never rendered; nothing writes to the `hasVat` store so the 1.2x VAT multiplier is permanently on; `catalog-info.yaml` is still the unfilled Backstage template.
- **ARCHITECTURE.md** — the real boot sequence (`index.html` → `/src/main.js` → `new App({ target: '#app' })`, Svelte 3 client API), the `App` → props → `Card` flow plus the one read-only store subscription in `Card.svelte`, the Open Props CDN styling and what breaks without it, `vite build` → `dist/`, and the absence of CI.
- **CONTRIBUTING.md** — install with `.npmrc`'s `ignore-scripts=true` intact, verify with `npm run build` / `npm run preview` since there is nothing else to run, `checkJs: true` in `jsconfig.json` as the closest thing to static analysis, Conventional Commit subjects matching existing history, and `.github/CODEOWNERS` review by `@contentful/team-devrel` as the only gate. Ends with the known rough edges above, in case someone wants a small first fix.

## ADR disclosure

The decision record documents the `ignore-scripts=true` setting in `.npmrc`, evidenced by commit `36331ef` ("chore: [] ignore npm scripts (#5)", 2025-11-26) — a one-line, one-file diff.

**It is explicitly marked as a reconstruction.** The original commit and PR title record no rationale, so the ADR carries a blockquote saying it was written on 2026-08-25 from commit history and documents an existing decision rather than a new one. It describes the mechanical effect of the npm setting and stops short of asserting intent; where it notes that the empty `[]` in the subject suggests a templated batch change, it labels that as inference from the message format rather than something the history confirms.

## Scope

Docs only — five new files, no existing file touched, no code, config, or `.gitignore` changes. No installs, builds, or test suites were run.

Refs DX-1340.